### PR TITLE
Fix typo in command ($PATH_TODSGRAB => $PATH_TO_DSGRAB)

### DIFF
--- a/webcam.php
+++ b/webcam.php
@@ -43,7 +43,7 @@ $REMOTE_NAME    = "<remote server>";
 $PATH_TO_WINSCP = "C:\Program Files\winscp3\winscp3.com";
 # Do the Capture
 $command = <<< EOT
-start /b {$PATH_TODSGRAB} -s -d "{$CAPTUREDEVICE}" -r {$IMAGEWIDTH}x{$IMAGEHEIGHT} -w 3000 {$PATH_TO_OUTPUT}.png
+start /b {$PATH_TO_DSGRAB} -s -d "{$CAPTUREDEVICE}" -r {$IMAGEWIDTH}x{$IMAGEHEIGHT} -w 3000 {$PATH_TO_OUTPUT}.png
 EOT;
 $output = array();
 $returnValue = 0;


### PR DESCRIPTION
There was a small bug in the script. Just fixed the typo.
